### PR TITLE
Fix classes to work with Python 2.7

### DIFF
--- a/src/basically_ti_basic/__main__.py
+++ b/src/basically_ti_basic/__main__.py
@@ -9,7 +9,8 @@ def compile_file(inputfile, outputfile):
         for line in f:
             file_lines.append(line)
 
-    compiled_file = PrgmCompiler.compile(file_lines)
+    compiler = PrgmCompiler()
+    compiled_file = compiler.compile(file_lines)
     if outputfile == "stdout":
         print("".join(compiled_file.prgmdata))
     else:
@@ -18,7 +19,8 @@ def compile_file(inputfile, outputfile):
 def decompile_file(inputfile, outputfile):
     tifile = TIPrgmFile(inputfile)
 
-    decompiled = PrgmCompiler.decompile(tifile)
+    compiler = PrgmCompiler()
+    decompiled = compiler.decompile(tifile)
     if outputfile == 'stdout':
         print("\n".join(decompiled))
     else:

--- a/src/basically_ti_basic/compiler/__init__.py
+++ b/src/basically_ti_basic/compiler/__init__.py
@@ -8,7 +8,7 @@ class PrgmCompiler(object):
     program files
     """
 
-    def compile(raw_text):
+    def compile(self, raw_text=None):
         """
         Compiles to 8Xp format. This logic works, but the TIFile class is
         incomplete so the file may not work properly on the TI calculator.
@@ -18,6 +18,14 @@ class PrgmCompiler(object):
         Returns:
             TIFile
         """
+        # To be compatible with Python 2.7 without changing
+        # the public class API, we do some gross magic. This
+        # has a side effect that we can use this method either
+        # as a static method or not.
+        # FIXME
+        if not isinstance(self, PrgmCompiler):
+            raw_text = self
+
         tifile = TIPrgmFile()
         tifile.prgmdata = []
         tokens = get_inverse_tokens()
@@ -45,7 +53,7 @@ class PrgmCompiler(object):
         return tifile
 
 
-    def decompile(tifile):
+    def decompile(self, tifile=None):
         """
         Decompiles to plaintext.
 
@@ -54,6 +62,15 @@ class PrgmCompiler(object):
         Returns:
             Array[string]
         """
+
+        # To be compatible with Python 2.7 without changing
+        # the public class API, we do some gross magic. This
+        # has a side effect that we can use this method either
+        # as a static method or not.
+        # FIXME
+        if not isinstance(self, PrgmCompiler):
+            tifile = self
+
         prgm_data = tifile.prgmdata
         plaintext = []
         tokens = get_tokens()


### PR DESCRIPTION
Fixes #1 

This was built and tested on Python 3, but other than a shortcut decision made to avoid large code changes while refactoring this to have somewhat of an API, there wasn't a reason for it not to work on Python 2.7. This adds a couple gross fixes for that until a more thorough refactoring gets done (which will cause a major version increase).
